### PR TITLE
Avoid error when receive travis hook

### DIFF
--- a/web.py
+++ b/web.py
@@ -90,6 +90,7 @@ def travis_app():
     req = json.loads(request.form.get('payload'))
     from pprint import pprint
     pprint(req)
+    return ''
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
To avoid `ValueError` when Popuko receives hook event from TravisCI.