### PR TITLE
Port to Golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ venv
 
 # application config
 settings.json
+
+# Golang
+vendor/
+gopuko/popuko
+gopuko/config.go
+!gopuko/config.go.example

--- a/gopuko/Gomfile
+++ b/gopuko/Gomfile
@@ -1,0 +1,2 @@
+gom 'github.com/google/go-github'
+gom 'golang.org/x/oauth2'

--- a/gopuko/Makefile
+++ b/gopuko/Makefile
@@ -1,0 +1,21 @@
+DIST_NAME := popuko
+CONFIGURE_FILE := ./config.go
+
+all: build
+
+clean:
+	rm -rf ./$(DIST_NAME)
+
+build: $(DIST_NAME)
+
+build_linux_x64:
+	env GOOS=linux GOARCH=amd64 make build -C .
+
+run: $(DIST_NAME)
+	./$(DIST_NAME)
+
+$(CONFIGURE_FILE):
+	cp $@.example $@
+
+$(DIST_NAME): clean $(CONFIGURE_FILE)
+	go build -o $(DIST_NAME)

--- a/gopuko/command_accept_changeset.go
+++ b/gopuko/command_accept_changeset.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/github"
+)
+
+func (srv *AppServer) commandAcceptChangesetByReviewer(ev *github.IssueCommentEvent) (bool, error) {
+	fmt.Printf("Start: assign the reviewer by %v\n", ev.Comment.ID)
+	defer fmt.Printf("End: assign the reviewer by %v\n", ev.Comment.ID)
+
+	sender := *ev.Sender.Login
+	if !config.Reviewers().Has(sender) {
+		fmt.Printf("%v is not an reviewer registred to this bot.\n", sender)
+		return false, nil
+	}
+
+	client := srv.githubClient
+	issueSvc := client.Issues
+
+	repoOwner := *ev.Repo.Owner.Login
+	repo := *ev.Repo.Name
+	issue := *ev.Issue.Number
+
+	currentLabels, _, err := issueSvc.ListLabelsByIssue(repoOwner, repo, issue, nil)
+	if err != nil {
+		fmt.Println("could not get labels by the issue")
+		return false, err
+	}
+	labels := addAwaitingMergeLabel(currentLabels)
+
+	// https://github.com/nekoya/popuko/blob/master/web.py
+	_, _, err = issueSvc.ReplaceLabelsForIssue(repoOwner, repo, issue, labels)
+	if err != nil {
+		fmt.Println("could not change labels by the issue")
+		return false, err
+	}
+
+	{
+		comment := "Try to merge this pull request which has been approved by `" + sender + "`"
+		_, _, err := issueSvc.CreateComment(repoOwner, repo, issue, &github.IssueComment{
+			Body: &comment,
+		})
+		if err != nil {
+			fmt.Println("could not create the comment to declare to merge this.")
+			return false, err
+		}
+	}
+
+	// XXX: the commit comment should be default?
+	prSvc := client.PullRequests
+	_, _, err = prSvc.Merge(repoOwner, repo, issue, "", nil)
+	if err != nil {
+		fmt.Println("could not merge pull request")
+		comment := "Could not merge this pull request by:\n```\n" + err.Error() + "\n```"
+		_, _, err := issueSvc.CreateComment(repoOwner, repo, issue, &github.IssueComment{
+			Body: &comment,
+		})
+		return false, err
+	}
+
+	// delete branch
+	/*
+		pr, _, err := prSvc.Get(repoOwner, repo, issue)
+		if err != nil {
+			fmt.Println("could not fetch the pull request information.")
+			return false, err
+		}
+
+		fmt.Printf("sender: %v\n", sender)
+		fmt.Printf("repo: %v\n", repo)
+		fmt.Printf("head ref: %v\n", *pr.Head.Ref)
+
+		_, err = client.Git.DeleteRef(repoOwner, repo, *pr.Head.Ref)
+		if err != nil {
+			fmt.Println("could not delete the merged branch.")
+			return false, err
+		}
+	*/
+
+	return true, nil
+}
+
+func (srv *AppServer) commandAcceptChangesetByOtherReviewer(ev *github.IssueCommentEvent, command string) (bool, error) {
+	tmp := strings.Split(command, "=")
+	if len(tmp) < 2 {
+		fmt.Println("No specify who is the actual reviewer.")
+		return false, nil
+	}
+
+	actual := tmp[1]
+	if !config.Reviewers().Has(actual) {
+		fmt.Println("could not find the actual reviewer in reviewer list")
+		return false, nil
+	}
+
+	return srv.commandAcceptChangesetByReviewer(ev)
+}

--- a/gopuko/command_assign_reviewer.go
+++ b/gopuko/command_assign_reviewer.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/github"
+)
+
+func (srv *AppServer) commandAssignReviewer(ev *github.IssueCommentEvent, target string) (bool, error) {
+	fmt.Printf("Start: assign the reviewer by %v\n", *ev.Comment.ID)
+	defer fmt.Printf("End: assign the reviewer by %v\n", *ev.Comment.ID)
+
+	client := srv.githubClient
+	issueSvc := client.Issues
+
+	repoOwner := *ev.Repo.Owner.Login
+	repo := *ev.Repo.Name
+	issue := *ev.Issue.Number
+
+	assignees := []string{target}
+
+	currentLabels, _, err := issueSvc.ListLabelsByIssue(repoOwner, repo, issue, nil)
+	if err != nil {
+		return false, err
+	}
+
+	_, _, err = issueSvc.AddAssignees(repoOwner, repo, issue, assignees)
+	if err != nil {
+		return false, err
+	}
+
+	labels := addAwaitingReviewLabel(currentLabels)
+	_, _, err = issueSvc.ReplaceLabelsForIssue(repoOwner, repo, issue, labels)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/gopuko/command_detect_unmergeable.go
+++ b/gopuko/command_detect_unmergeable.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/go-github/github"
+)
+
+func (srv *AppServer) detectUnmergeablePR(ev *github.PushEvent) {
+	if *ev.Ref != "refs/heads/master" {
+		fmt.Println(*ev.Ref)
+		return
+	}
+
+	repoOwner := *ev.Repo.Owner.Name
+	repo := *ev.Repo.Name
+
+	client := srv.githubClient
+	prSvc := client.PullRequests
+
+	prList, _, err := prSvc.List(repoOwner, repo, &github.PullRequestListOptions{
+		State: "open",
+	})
+	if err != nil {
+		fmt.Println("could not fetch opened pull requests")
+		return
+	}
+
+	compare := *ev.Compare
+	comment := ":umbrella: The latest upstream [changeset](" + compare + ") made this pull request unmergeable. Please resolve the merge conflicts."
+	wg := &sync.WaitGroup{}
+	for _, item := range prList {
+		wg.Add(1)
+
+		go markUnmergeable(wg, client.Issues, &markUnmergeableInfo{
+			repoOwner,
+			repo,
+			*item.Number,
+			comment,
+		})
+	}
+	wg.Wait()
+}
+
+type markUnmergeableInfo struct {
+	RepoOwner string
+	Repo      string
+	Number    int
+	Comment   string
+}
+
+func markUnmergeable(wg *sync.WaitGroup, issueSvc *github.IssuesService, info *markUnmergeableInfo) {
+	var err error
+	defer wg.Done()
+	defer func() {
+		if err != nil {
+			fmt.Printf("error: %v\n", err)
+		}
+	}()
+
+	repoOwner := info.RepoOwner
+	repo := info.Repo
+	number := info.Number
+
+	currentLabels, _, err := issueSvc.ListLabelsByIssue(repoOwner, repo, number, nil)
+	if err != nil {
+		fmt.Println("could not get labels by the issue")
+		return
+	}
+
+	// We don't have to warn to a pull request which have been marked as unmergeable.
+	if hasStatusLabel(currentLabels, LABEL_NEEDS_REBASE) {
+		return
+	}
+
+	_, _, err = issueSvc.CreateComment(repoOwner, repo, number, &github.IssueComment{
+		Body: &info.Comment,
+	})
+	if err != nil {
+		fmt.Println("could not create the comment to unmergeables")
+		return
+	}
+
+	labels := addNeedRebaseLabel(currentLabels)
+	_, _, err = issueSvc.ReplaceLabelsForIssue(repoOwner, repo, number, labels)
+	if err != nil {
+		fmt.Println("could not change labels of the issue")
+		return
+	}
+}

--- a/gopuko/config.go.example
+++ b/gopuko/config.go.example
@@ -1,0 +1,18 @@
+package main
+
+var config *Settings = &Settings{
+	botName: "popuko",
+	port: 3000,
+
+	github: GithubSetting{
+		// If your github bot name is different from global botname,
+		// please specify this. Otherwise, you should set empty string.
+		botName: "",
+		token:      "",
+		hookSecret: "",
+		reviewerList: &[]string{
+			"bob",
+			"anne",
+		},
+	},
+}

--- a/gopuko/label.go
+++ b/gopuko/label.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/google/go-github/github"
+)
+
+const (
+	STATUS_LABEL_PREFIX   string = "S-"
+	LABEL_AWAITING_REVIEW string = "S-awaiting-review"
+	LABEL_AWAITING_MERGE  string = "S-awaiting-merge"
+	LABEL_NEEDS_REBASE    string = "S-needs-rebase"
+)
+
+func addAwaitingReviewLabel(list []*github.Label) []string {
+	return changeStatusLabel(list, LABEL_AWAITING_REVIEW)
+}
+
+func addAwaitingMergeLabel(list []*github.Label) []string {
+	return changeStatusLabel(list, LABEL_AWAITING_MERGE)
+}
+
+func addNeedRebaseLabel(list []*github.Label) []string {
+	return changeStatusLabel(list, LABEL_NEEDS_REBASE)
+}
+
+func changeStatusLabel(list []*github.Label, new string) []string {
+	result := make([]string, 0, 0)
+	for _, item := range list {
+		label := *item.Name
+		if strings.Index(label, STATUS_LABEL_PREFIX) == 0 {
+			continue
+		} else {
+			result = append(result, label)
+		}
+	}
+	result = append(result, new)
+	return result
+}
+
+func hasStatusLabel(list []*github.Label, target string) bool {
+	for _, item := range list {
+		label := *item.Name
+		if label == target {
+			return true
+		}
+	}
+	return false
+}

--- a/gopuko/main.go
+++ b/gopuko/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	config.Init()
+
+	fmt.Println("===== popuko =====")
+	fmt.Printf("listen http on port: %v\n", config.PortStr())
+	fmt.Printf("botname for GitHub: %v\n", config.BotNameForGithub())
+	fmt.Println("==================")
+
+	github := createGithubClient(config)
+	if github == nil {
+		panic("Cannot create the github client")
+	}
+
+	server := AppServer{github}
+
+	http.HandleFunc("/github", server.handleGithubHook)
+	http.ListenAndServe(config.PortStr(), nil)
+}

--- a/gopuko/server.go
+++ b/gopuko/server.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// AppServer is just an this application.
+type AppServer struct {
+	githubClient *github.Client
+}
+
+func (srv *AppServer) handleGithubHook(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != "POST" {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	payload, err := github.ValidatePayload(req, config.WebHookSecret())
+	if err != nil {
+		rw.WriteHeader(http.StatusPreconditionFailed)
+		io.WriteString(rw, err.Error())
+		return
+	}
+
+	event, err := github.ParseWebHook(github.WebHookType(req), payload)
+	if err != nil {
+		rw.WriteHeader(http.StatusPreconditionFailed)
+		io.WriteString(rw, err.Error())
+		return
+	}
+
+	switch event := event.(type) {
+	case *github.IssueCommentEvent:
+		ok, err := srv.processIssueCommentEvent(event)
+		if ok {
+			io.WriteString(rw, "result: \n")
+		}
+
+		if err != nil {
+			io.WriteString(rw, err.Error())
+		}
+
+		rw.WriteHeader(http.StatusOK)
+		return
+	case *github.PushEvent:
+		srv.processPushEvent(event)
+		rw.WriteHeader(http.StatusOK)
+		return
+	default:
+		rw.WriteHeader(http.StatusOK)
+		fmt.Println(reflect.TypeOf(event))
+		io.WriteString(rw, "This event type is not supported: "+github.WebHookType(req))
+		return
+	}
+}
+
+func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bool, error) {
+	fmt.Printf("Start: processCommitCommentEvent by %v\n", *ev.Comment.ID)
+	defer fmt.Printf("End: processCommitCommentEvent by %v\n", *ev.Comment.ID)
+
+	body := ev.Comment.Body
+	tmp := strings.Split(*body, " ")
+
+	// If there are no possibility that the comment body is not formatted
+	// `@botname command`, stop to process.
+	if len(tmp) < 2 {
+		err := fmt.Errorf("The comment body is not expected format: `%v`\n", body)
+		return false, err
+	}
+
+	trigger := tmp[0]
+	command := tmp[1]
+
+	fmt.Printf("trigger: %v\n", trigger)
+	fmt.Printf("command: %v\n", command)
+
+	var args string
+	if len(tmp) > 2 {
+		args = tmp[2]
+		fmt.Printf("args: %v\n", args)
+	}
+
+	// `@reviewer r?`
+	{
+		target := strings.TrimPrefix(trigger, "@")
+		if config.Reviewers().Has(target) && command == "r?" {
+			return srv.commandAssignReviewer(ev, target)
+		}
+	}
+
+	// not for me
+	if trigger != config.BotNameForGithub() {
+		err := fmt.Errorf("The trigger is not me: `%v`\n", trigger)
+		return false, err
+	}
+
+	// `@botname command`
+	if command == "r+" {
+		return srv.commandAcceptChangesetByReviewer(ev)
+	} else if strings.Index(command, "r=") == 0 {
+		return srv.commandAcceptChangesetByOtherReviewer(ev, command)
+	}
+
+	return false, fmt.Errorf("No operations which this bot should handle.")
+}
+
+func (srv *AppServer) processPushEvent(ev *github.PushEvent) {
+	fmt.Printf("Start: processPushEvent by push id: %v\n", ev.PushID)
+	defer fmt.Printf("End: processPushEvent by push id: %v\n", ev.PushID)
+	srv.detectUnmergeablePR(ev)
+}
+
+func createGithubClient(config *Settings) *github.Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{
+			AccessToken: config.GithubToken(),
+		},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	client := github.NewClient(tc)
+	return client
+}

--- a/gopuko/setting.go
+++ b/gopuko/setting.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strconv"
+)
+
+type Settings struct {
+	botName string
+	port    uint64
+	github  GithubSetting
+}
+
+type GithubSetting struct {
+	botName      string
+	token        string
+	hookSecret   string
+	reviewerList *[]string
+	reviewers    *ReviewerSet
+}
+
+func (s *Settings) PortStr() string {
+	return ":" + strconv.FormatUint(s.port, 10)
+}
+
+func (s *Settings) Init() {
+	set := newReviewerSet(*s.github.reviewerList)
+	s.github.reviewerList = nil
+	s.github.reviewers = set
+}
+
+func (s *Settings) BotNameForGithub() string {
+	github := s.github.botName
+	if github != "" {
+		return "@" + github
+	} else {
+		return "@" + s.botName
+	}
+}
+
+func (s *Settings) GithubToken() string {
+	return s.github.token
+}
+
+func (s *Settings) WebHookSecret() []byte {
+	return []byte(s.github.hookSecret)
+}
+
+func (s *Settings) Reviewers() *ReviewerSet {
+	return s.github.reviewers
+}
+
+type ReviewerSet struct {
+	set map[string]*interface{}
+}
+
+func (s *ReviewerSet) Has(person string) bool {
+	_, ok := s.set[person]
+	return ok
+}
+
+func newReviewerSet(list []string) *ReviewerSet {
+	s := make(map[string]*interface{})
+	for _, name := range list {
+		s[name] = nil
+	}
+
+	return &ReviewerSet{
+		s,
+	}
+}


### PR DESCRIPTION
- This pull request re-implements features by Golang.
   - I name this project as "gopuko" (go porting popuko).
- I'll switch gopuko to mainline and remove all python codes.

## Why Golang?

- I'd like to use https://github.com/google/go-github.
- It's more easier to develop by static typing.
- We can create an ultimate portable execution binary.

## How to setup

1. `cd gopuko/`
2. [`gom install`](https://github.com/mattn/gom)
3. `cp config.go.example config.go`
    - For building a single binary which contains all configure at the compile time.
    - This process should be handled by `go generate` for the future.
4. FIll `config.go`
5. `make build`

## TODO

- [x] Implement features:
  - [x] Assign to an reviewer.
  - [x] `r+` from the reviewer.
  - [x] `r+` from other reviewers.
- [x] Check this works actually.

## Out of Scope in this pull request

- Corporate with slack.
- Corporate with TravisCI.
- Write test codes.
- Replace exist code bases.