### PR TITLE
Support OWNERS file

### DIFF
--- a/command_accept_changeset.go
+++ b/command_accept_changeset.go
@@ -8,8 +8,9 @@ import (
 )
 
 type AcceptCommand struct {
-	client *github.Client
-	repo   *RepositorySetting
+	client    *github.Client
+	repo      *RepositorySetting
+	reviewers *ReviewerSet
 }
 
 func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueCommentEvent) (bool, error) {
@@ -19,7 +20,7 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 	sender := *ev.Sender.Login
 	log.Printf("debug: command is sent from %v\n", sender)
 
-	if !c.repo.Reviewers().Has(sender) {
+	if !c.reviewers.Has(sender) {
 		log.Printf("info: %v is not an reviewer registred to this bot.\n", sender)
 		return false, nil
 	}
@@ -109,7 +110,7 @@ func (c *AcceptCommand) commandAcceptChangesetByOtherReviewer(ev *github.IssueCo
 	}
 
 	actual := tmp[1]
-	if !c.repo.Reviewers().Has(actual) {
+	if !c.reviewers.Has(actual) {
 		log.Println("info: could not find the actual reviewer in reviewer list")
 		log.Printf("debug: specified actial reviewer %v\n", actual)
 		return false, nil

--- a/config.go.example
+++ b/config.go.example
@@ -25,6 +25,13 @@ var config *Settings = &Settings{
 				// restriction. This only clean up only the upstream repository
 				// managed by this bot.
 				shouldDeleteMerged: false,
+
+				// Use `/OWNERS.json` in your repository's `master` branch
+				// to list reviewers.
+				// This option is prior to the value of `RepositorySetting.reviewerList`.
+				// If you don't like to manage reviewers for each `OWNERS.json` in repositories,
+				// Disable this option.
+				useOwnersFile: true,
 			},
 		},
 	},


### PR DESCRIPTION
- Fix https://github.com/nekoya/popuko/issues/2
- This feature is not enabled by default. Because we consider about these cases:
  - The project has `OWNERS` file which are other format.
  - Manage all repositories by config files.