### PR TITLE
Add option to disallow to merge pull request by this bot.

### DIFF
--- a/config.go.example
+++ b/config.go.example
@@ -20,6 +20,11 @@ func createSettings() *Settings {
 						"pipimi",
 					},
 
+					// By default, this bot merge branch automatically after you command `r+`.
+					// If you merge by hand and this bot should change the status label,
+					// disable this option.
+					shouldMergeAutomatically: true,
+
 					// Delete the branch by this bot after this bot had merged it
 					// if you enable this option.
 					// The operation may not delete contributor's branch by API

--- a/setting.go
+++ b/setting.go
@@ -86,7 +86,8 @@ type RepositorySetting struct {
 	reviewerList []string
 	reviewers    ReviewerSet
 
-	shouldDeleteMerged bool
+	shouldMergeAutomatically bool
+	shouldDeleteMerged       bool
 	// Use `OWNERS` file as reviewer list in the repository's root.
 	useOwnersFile bool
 }
@@ -111,6 +112,10 @@ func (s *RepositorySetting) Fullname() string {
 
 func (s *RepositorySetting) Reviewers() *ReviewerSet {
 	return &s.reviewers
+}
+
+func (r *RepositorySetting) ShouldMergeAutomatically() bool {
+	return r.shouldMergeAutomatically
 }
 
 func (r *RepositorySetting) ShouldDeleteMerged() bool {


### PR DESCRIPTION
- This increase the compatibility with the workflow that is that some repository enforce to try CI before merging.
- Essentially, we should implement https://github.com/nekoya/popuko/issues/45 to corporate with such workflow. But there are some projects which would not like to use the bot to merge their pull request.
- We will refactor settings by https://github.com/nekoya/popuko/issues/62