### PR TITLE
Part 2: Implement the in-memory queue to manage the auto branch.

### DIFF
--- a/command_accept_changeset.go
+++ b/command_accept_changeset.go
@@ -14,6 +14,8 @@ type AcceptCommand struct {
 	botName string
 	cmd     AcceptChangesetCommand
 	info    *repositoryInfo
+
+	queue *autoMergeQueue
 }
 
 func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueCommentEvent) (bool, error) {
@@ -76,6 +78,9 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 
 	if c.info.EnableAutoMerge {
 		if c.info.ExperimentalTryOnAutoBranch() {
+			c.queue.Lock()
+			defer c.queue.Unlock()
+
 			ok, _ := createBranchFromMaster(client.Git, repoOwner, repoName, "auto")
 			if !ok {
 				log.Println("info: cannot create the auto branch")

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		panic("Cannot create the github client")
 	}
 
-	server := AppServer{github}
+	server := AppServer{github, newAutoMergeQRepo()}
 
 	http.HandleFunc("/github", server.handleGithubHook)
 	http.ListenAndServe(config.PortStr(), nil)

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+type autoMergeQRepo struct {
+	mux sync.Mutex
+	m   map[string]*autoMergeQueue
+}
+
+func newAutoMergeQRepo() *autoMergeQRepo {
+	return &autoMergeQRepo{
+		mux: sync.Mutex{},
+	}
+}
+
+func (s *autoMergeQRepo) Lock() {
+	s.mux.Lock()
+}
+
+func (s *autoMergeQRepo) Unlock() {
+	s.mux.Unlock()
+}
+
+func (s *autoMergeQRepo) Get(owner string, name string) *autoMergeQueue {
+	k := owner + "/" + name
+	item, ok := s.m[k]
+	if !ok {
+		n := &autoMergeQueue{}
+		s.m[k] = n
+		return n
+	}
+
+	return item
+}
+
+func (s *autoMergeQRepo) Remove(owner string, name string) {
+	k := owner + "/" + name
+	delete(s.m, k)
+}
+
+func (s *autoMergeQRepo) Save(owner string, name string, v *autoMergeQueue) {
+	k := owner + "/" + name
+	s.m[k] = v
+}
+
+type autoMergeQueue struct {
+	isLocked bool
+	mux      sync.Mutex
+	q        []*autoMergeQueueItem
+	current  *autoMergeQueueItem
+}
+
+func (s *autoMergeQueue) Lock() {
+	s.mux.Lock()
+}
+
+func (s *autoMergeQueue) Unlock() {
+	s.mux.Unlock()
+}
+
+func (s *autoMergeQueue) Push(item *autoMergeQueueItem) {
+	s.q = append(s.q, item)
+}
+
+func (s *autoMergeQueue) GetNext() (ok bool, item *autoMergeQueueItem) {
+	if len(s.q) == 0 {
+		return true, nil
+	}
+
+	f, q := s.q[0], s.q[1:]
+	s.q = q
+
+	if f == nil {
+		log.Println("error: the front of auto merge queue is nil")
+		return
+	}
+
+	return true, f
+}
+
+func (s *autoMergeQueue) GetActive() *autoMergeQueueItem {
+	return s.current
+}
+
+func (s *autoMergeQueue) SetActive(item *autoMergeQueueItem) error {
+	if s.HasActive() {
+		return fmt.Errorf("warn: active item has been already set!")
+	}
+
+	s.current = item
+	return nil
+}
+
+func (s *autoMergeQueue) RemoveActive() {
+	s.current = nil
+}
+
+func (s *autoMergeQueue) HasActive() bool {
+	return s.current == nil
+}
+
+type autoMergeQueueItem struct {
+	PullRequest int
+	SHA         string
+}


### PR DESCRIPTION
- This implements the in-memory queue to manage the auto branch.
  - By this pull request, there are no persistent queue.
- This does not implement full auto branch implementations.
- This add the queue which has bared `sync.Locker` interface.
  - I know this APIs causes a deadlock easily.
  - So be careful to treat it :)

## Related issues

- depend on https://github.com/nekoya/popuko/pull/79
- #45

